### PR TITLE
Removed duplicate 'openpyxl' requirement with syntax error.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,8 +22,7 @@ setup(
         "SimpleITK==2.2.1",
         "scikit-image==0.22.0",
         "torch==2.0.1+cu117",
-        "tqdm==4.66.1",
-        "openpyxl=3.1.5"
+        "tqdm==4.66.1"
     ],
     classifiers=[
         "Programming Language :: Python :: 3",


### PR DESCRIPTION
Final requirement in `setup.py` was `"openpyxl=3.1.5"`, which results in a syntax error from the single `=`. 

Note that earlier in the requirements list in this file openpyxl version 3.1.2 is used. So if 3.1.5 is preferable, this will need to get updated, both in `setup.py` and `requirements.txt`.